### PR TITLE
We believe these secrets are overridding values.yaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,4 @@ GET http://localhost:8080/api/v1/examples
 GET http://localhost:8080/api/v1/examples/1
 POST http://localhost:8080/api/v1/examples
 
-
 END

--- a/charts/xui-terms-and-conditions/Chart.yaml
+++ b/charts/xui-terms-and-conditions/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xui-terms-and-conditions
 home: https://github.com/hmcts/rpx-xui-terms-and-conditions
-version: 0.1.6
+version: 0.1.7
 description: Terms and Conditions
 maintainers:
   - name: HMCTS RPX XUI

--- a/config/aat.yaml
+++ b/config/aat.yaml
@@ -5,10 +5,6 @@ database:
   username: POSTGRES_USERNAME
   port: POSTGRES_SERVER_PORT
   ssl: POSTGRES_SSL
-secrets:
-  rpx:
-    postgresql-admin-pw: POSTGRES_PASSWORD
-    appinsights-instrumentationkey-tc: APPINSIGHTS_INSTRUMENTATIONKEY
 proxy:
   host: PROXY_HOST
   port: PROXY_PORT

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -5,10 +5,6 @@ database:
   username: POSTGRES_USERNAME
   port: POSTGRES_SERVER_PORT
   ssl: POSTGRES_SSL
-secrets:
-  rpx:
-    postgresql-admin-pw: POSTGRES_PASSWORD
-    appinsights-instrumentationkey-tc: APPINSIGHTS_INSTRUMENTATIONKEY
 proxy:
   host: PROXY_HOST
   port: PROXY_PORT

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -5,10 +5,6 @@ database:
   username: POSTGRES_USERNAME
   port: POSTGRES_SERVER_PORT
   ssl: POSTGRES_SSL
-secrets:
-  rpx:
-    postgresql-admin-pw: POSTGRES_PASSWORD
-    appinsights-instrumentationkey-tc: APPINSIGHTS_INSTRUMENTATIONKEY
 proxy:
   host: PROXY_HOST
   port: PROXY_PORT

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -5,10 +5,6 @@ database:
   username: POSTGRES_USERNAME
   port: POSTGRES_SERVER_PORT
   ssl: POSTGRES_SSL
-secrets:
-  rpx:
-    postgresql-admin-pw: POSTGRES_PASSWORD
-    appinsights-instrumentationkey-tc: APPINSIGHTS_INSTRUMENTATIONKEY
 proxy:
   host: PROXY_HOST
   port: PROXY_PORT

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -5,10 +5,6 @@ database:
   username: POSTGRES_USERNAME
   port: POSTGRES_SERVER_PORT
   ssl: POSTGRES_SSL
-secrets:
-  rpx:
-    postgresql-admin-pw: POSTGRES_PASSWORD
-    appinsights-instrumentationkey-tc: APPINSIGHTS_INSTRUMENTATIONKEY
 proxy:
   host: PROXY_HOST
   port: PROXY_PORT


### PR DESCRIPTION
Remove secrets from /config/aat.yaml as we believe that on the Flux config environments these are overwriting the values from xui-terms-and-conditions/values.yaml