### PR TITLE
Within the Jenkins build, rpx is undefined, as there are no environme…

### DIFF
--- a/server/api/configuration/index.ts
+++ b/server/api/configuration/index.ts
@@ -1,4 +1,5 @@
 import config from 'config';
+import { propsExist } from '../utils/objectUtilities';
 
 /**
  * Get Environment
@@ -114,7 +115,7 @@ export const getDynamicSecret = (secret, fallbackSecret): string => {
  *
  * @returns {string}
  */
-export const getPostgresSecret = (environmentSecret, environment): string => {
+export const getPostgresSecret = (secretsConfig, environment): string => {
     const PREVIEW = 'preview';
     const ERROR_POSTGRES_SECRET_NOT_FOUND =
         'secrets.rpx.postgresql-admin-pw not found on this environment, please ' +
@@ -124,10 +125,9 @@ export const getPostgresSecret = (environmentSecret, environment): string => {
         return config.get('database.password');
     }
 
-    // The environment secrete should be found on
-    // all environments.
-    if (environmentSecret) {
-        return environmentSecret;
+    if (propsExist(secretsConfig, ['secrets', 'rpx', 'postgresql-admin-pw'])) {
+        console.log(secretsConfig['secrets']['rpx']['postgresql-admin-pw']);
+        return secretsConfig['secrets']['rpx']['postgresql-admin-pw'];
     } else {
         console.log(ERROR_POSTGRES_SECRET_NOT_FOUND);
         return '';

--- a/server/api/controllers/config/configController.ts
+++ b/server/api/controllers/config/configController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import config from 'config';
 import * as secretsConfig from 'config';
+import { getPostgresSecret } from '../../configuration'
 
 export class ConfigController {
 
@@ -21,7 +22,7 @@ export class ConfigController {
             username: config.get<string>('database.username'),
 
             // Postgres Password
-            password: secretsConfig['secrets']['rpx']['postgresql-admin-pw'],
+            password: getPostgresSecret(secretsConfig, config.get('environment'))
         }
 
         console.log(config.get<string>('environment'));

--- a/server/database/index.ts
+++ b/server/database/index.ts
@@ -49,7 +49,7 @@ export const environmentDatabaseConfig = (config: config.IConfig) => {
         port: parseInt(config.get<string>('database.port'), 10) as number,
         database: config.get<string>('database.name'),
         user: config.get<string>('database.username'),
-        password: getPostgresSecret(secretsConfig['secrets']['rpx']['postgresql-admin-pw'], config.get('environment')),
+        password: getPostgresSecret(secretsConfig, config.get('environment')),
     };
 };
 
@@ -76,8 +76,7 @@ const setPgp = (unitTestEnvironment) => {
         console.log(`POSTGRES_SERVER_PORT: ${config.get('database.port')}`);
         console.log(`POSTGRES_SSL: ${config.get('database.ssl')}`);
         console.log(`POSTGRES_PASSWORD: ${config.get('database.password')}`);
-        console.log(secretsConfig['secrets']['rpx']['postgresql-admin-pw']);
-        console.log(`POSTGRES_SECRET_DYNAMIC: ${getPostgresSecret(secretsConfig['secrets']['rpx']['postgresql-admin-pw'], config.get('environment'))}`);
+        console.log(`POSTGRES_SECRET_DYNAMIC: ${getPostgresSecret(secretsConfig, config.get('environment'))}`);
 
         /**
          * Do not use SSL on the Jenkins Preview Environment as it's not enabled


### PR DESCRIPTION
Within the Jenkins build, rpx is undefined, as there are no secrets on the build, therefore we check that rpx exists if it does not then we return an empty string.