### PR TITLE
Feature/attempting fix 14

### DIFF
--- a/charts/xui-terms-and-conditions/Chart.yaml
+++ b/charts/xui-terms-and-conditions/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: xui-terms-and-conditions
 home: https://github.com/hmcts/rpx-xui-terms-and-conditions
-version: 0.1.18
+version: 0.1.19
 description: Terms and Conditions
 maintainers:
   - name: HMCTS RPX XUI

--- a/server/api/configuration/index.ts
+++ b/server/api/configuration/index.ts
@@ -118,8 +118,8 @@ export const getDynamicSecret = (secret, fallbackSecret): string => {
 export const getPostgresSecret = (secretsConfig, environment): string => {
     const PREVIEW = 'preview';
     const ERROR_POSTGRES_SECRET_NOT_FOUND =
-        'secrets.rpx.postgresql-admin-pw not found on this environment, please ' +
-        'make sure its setup within /mnt/secrets.';
+        'secrets.rpx.postgresql-admin-pw not found on this environment, therefore using the password in the .yaml' +
+        'file for this environment.';
 
     if (environment === PREVIEW) {
         console.log('using');
@@ -127,12 +127,17 @@ export const getPostgresSecret = (secretsConfig, environment): string => {
         return config.get('database.password');
     }
 
+    // aat env gets to here, and it will use this if it's available.
+    // but the secret is not available on the build environment, therefore we need to fallback to
+    // database.password As the build runs a migration script which is required
+    // to setup the DB. Hopefully this just works in flux. as secrets.rpx.postgresql-admin-pw
+    // should hopefully be in flux.
     if (propsExist(secretsConfig, ['secrets', 'rpx', 'postgresql-admin-pw'])) {
         console.log(secretsConfig['secrets']['rpx']['postgresql-admin-pw']);
         return secretsConfig['secrets']['rpx']['postgresql-admin-pw'];
     } else {
         console.log(ERROR_POSTGRES_SECRET_NOT_FOUND);
-        return '';
+        return config.get('database.password');
     }
 };
 


### PR DESCRIPTION
Fixing the Jenkins Build Process not having a secrets.rpx.postgresql-admin-pw password available, it uses .yaml.